### PR TITLE
let's see if this keeps us at builds +4

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.17
+FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.19
 WORKDIR /app
 ENV GOPRIVATE=github.com/TriggerMail
 
@@ -34,7 +34,7 @@ build:
     SAVE ARTIFACT ./bin/buildkite-gcp-autoscaler /buildkite-gcp-autoscaler
 
 docker:
-    FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.17
+    FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.19
     ARG EARTHLY_GIT_SHORT_HASH
     COPY +build/buildkite-gcp-autoscaler /buildkite-gcp-autoscaler
     ENTRYPOINT ["/buildkite-gcp-autoscaler"]

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -108,8 +108,8 @@ func (s *Scaler) run(ctx context.Context, sem *chan int) error {
 	if liveInstanceCount >= totalInstanceRequirement {
 		return nil
 	}
-
-	required := totalInstanceRequirement - liveInstanceCount
+	// required equals total instance needs minus liveinstance count but have 4 instances ready at any time for new work
+	required := totalInstanceRequirement - liveInstanceCount + 4
 
 	errChan := make(chan error, 1)
 	wg := new(sync.WaitGroup)


### PR DESCRIPTION
* always have 4 more instances ready than the current "demand" to decrease scheduled time 