### PR TITLE
add a minimum of 1 instance for buildkite oneshot

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,8 +3,16 @@ env:
   HOMEBREW_GITHUB_API_TOKEN: ${HOMEBREW_GITHUB_API_TOKEN}
 name: buildkite-gcp-scaler
 description: buildkite-gcp-scaler build pipeline
+
+docker_login_config: &docker_login_config
+  username: _json_key
+  password-env: BUILDKITE_PLUGIN_GCR_JSON_KEY
+  server: https://us-central1-docker.pkg.dev
+  retries: 3
+
 steps:
   - label: ":golang:"
     key: "build"
     command: ".buildkite/steps/build"
-
+    plugins:
+    - docker-login#v2.1.0: *docker_login_config

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.7
-FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.19
+FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.22
 WORKDIR /app
 ENV GOPRIVATE=github.com/TriggerMail
 
@@ -34,7 +34,7 @@ build:
     SAVE ARTIFACT ./bin/buildkite-gcp-autoscaler /buildkite-gcp-autoscaler
 
 docker:
-    FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.19
+    FROM us.gcr.io/bluecore-ops/dockerfiles/golang:lint-1.22
     ARG EARTHLY_GIT_SHORT_HASH
     COPY +build/buildkite-gcp-autoscaler /buildkite-gcp-autoscaler
     ENTRYPOINT ["/buildkite-gcp-autoscaler"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TriggerMail/buildkite-gcp-scaler
 
-go 1.19
+go 1.22
 
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/genuinetools/pkg v0.0.0-20181022210355-2fcf164d37cb
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/api v0.103.0
 )
 
@@ -16,6 +17,7 @@ require (
 	cloud.google.com/go/compute v1.12.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.1 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
@@ -23,6 +25,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
@@ -32,4 +35,5 @@ require (
 	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c // indirect
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ cloud.google.com/go/compute v1.12.1/go.mod h1:e8yNOBcBONZU1vJKCvCoDw/4JQsA0dpM4x
 cloud.google.com/go/compute/metadata v0.2.1 h1:efOwf5ymceDhK6PKMnnrTHP4pppY5L22mle96M1yP48=
 cloud.google.com/go/compute/metadata v0.2.1/go.mod h1:jgHgmJd2RKBGzXqF5LR2EZMGxBkeanZ9wwa75XHJgOM=
 cloud.google.com/go/longrunning v0.1.1 h1:y50CXG4j0+qvEukslYFBCrzaXX0qpFbBzc3PchSu/LE=
+cloud.google.com/go/longrunning v0.1.1/go.mod h1:UUFxuDWkv22EuY93jjmDMFT5GPQKeFVJBIF6QlTqdsE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -51,6 +52,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -123,6 +125,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.103.0 h1:9yuVqlu2JCvcLg9p8S3fcFLZij8EPSyvODIY1rkMizQ=
 google.golang.org/api v0.103.0/go.mod h1:hGtW6nK1AC+d9si/UBhw8Xli+QMOf6xyNAyJw4qU9w0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -1,0 +1,302 @@
+package scaler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/TriggerMail/buildkite-gcp-scaler/pkg/buildkite"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Mocks ---
+
+type mockBuildkite struct {
+	metrics *buildkite.AgentMetrics
+	err     error
+}
+
+func (m *mockBuildkite) GetAgentMetrics(ctx context.Context, queue string) (*buildkite.AgentMetrics, error) {
+	return m.metrics, m.err
+}
+
+type mockGCE struct {
+	liveCount int64
+	liveErr   error
+
+	launchErr error
+	launches  int
+	mu        sync.Mutex
+}
+
+func (m *mockGCE) LiveInstanceCount(ctx context.Context, projectID, zone, instanceGroupName string) (int64, error) {
+	return m.liveCount, m.liveErr
+}
+
+func (m *mockGCE) LaunchInstanceForGroup(ctx context.Context, projectID, zone, groupName, templateName string, maxRunDuration int64) error {
+	m.mu.Lock()
+	m.launches++
+	m.mu.Unlock()
+	return m.launchErr
+}
+
+type mockStatsd struct {
+	statsd.NoOpClient
+	calls []string
+	mu    sync.Mutex
+}
+
+func (m *mockStatsd) Gauge(name string, value float64, tags []string, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, name)
+	return nil
+}
+
+// --- Tests ---
+
+func TestScalerRun_NoScalingNeeded(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 2)
+
+	bk := &mockBuildkite{
+		metrics: &buildkite.AgentMetrics{
+			ScheduledJobs: 2,
+			RunningJobs:   2,
+		},
+	}
+	gce := &mockGCE{
+		liveCount: 4,
+	}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg: &Config{
+			GCPProject:            "proj",
+			GCPZone:               "zone",
+			InstanceGroupName:     "group",
+			InstanceGroupTemplate: "tmpl",
+			MaxRunDuration:        60,
+		},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	err := scaler.run(ctx, &sem)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, gce.launches)
+}
+
+func TestScalerRun_ScalingNeeded(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 2)
+
+	bk := &mockBuildkite{
+		metrics: &buildkite.AgentMetrics{
+			ScheduledJobs: 3,
+			RunningJobs:   2,
+		},
+	}
+	gce := &mockGCE{
+		liveCount: 2,
+	}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg: &Config{
+			GCPProject:            "proj",
+			GCPZone:               "zone",
+			InstanceGroupName:     "group",
+			InstanceGroupTemplate: "tmpl",
+			MaxRunDuration:        60,
+		},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	err := scaler.run(ctx, &sem)
+	assert.NoError(t, err)
+	// Should launch 3 instances (5 needed - 2 live)
+	assert.Equal(t, 3, gce.launches)
+}
+
+func TestScalerRun_AlwaysAtLeastOneInstance(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 2)
+
+	bk := &mockBuildkite{
+		metrics: &buildkite.AgentMetrics{
+			ScheduledJobs: 0,
+			RunningJobs:   0,
+		},
+	}
+	gce := &mockGCE{
+		liveCount: 0,
+	}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg: &Config{
+			GCPProject:            "proj",
+			GCPZone:               "zone",
+			InstanceGroupName:     "group",
+			InstanceGroupTemplate: "tmpl",
+			MaxRunDuration:        60,
+		},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	err := scaler.run(ctx, &sem)
+	assert.NoError(t, err)
+	// Should launch at least 1 instance
+	assert.Equal(t, 1, gce.launches)
+}
+
+func TestScalerRun_BuildkiteError(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 2)
+
+	bk := &mockBuildkite{
+		err: errors.New("buildkite error"),
+	}
+	gce := &mockGCE{}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg:       &Config{},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	err := scaler.run(ctx, &sem)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "buildkite error")
+}
+
+func TestScalerRun_GCECountError(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 2)
+
+	bk := &mockBuildkite{
+		metrics: &buildkite.AgentMetrics{
+			ScheduledJobs: 1,
+			RunningJobs:   1,
+		},
+	}
+	gce := &mockGCE{
+		liveErr: errors.New("gce count error"),
+	}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg:       &Config{},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	err := scaler.run(ctx, &sem)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "gce count error")
+}
+
+func TestScalerRun_LaunchInstanceError(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 2)
+
+	bk := &mockBuildkite{
+		metrics: &buildkite.AgentMetrics{
+			ScheduledJobs: 2,
+			RunningJobs:   0,
+		},
+	}
+	gce := &mockGCE{
+		liveCount: 0,
+		launchErr: errors.New("launch error"),
+	}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg: &Config{
+			GCPProject:            "proj",
+			GCPZone:               "zone",
+			InstanceGroupName:     "group",
+			InstanceGroupTemplate: "tmpl",
+			MaxRunDuration:        60,
+		},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	err := scaler.run(ctx, &sem)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "launch error")
+	assert.Equal(t, 2, gce.launches)
+}
+
+func TestScalerRun_ConcurrencyRespected(t *testing.T) {
+	ctx := context.Background()
+	sem := make(chan int, 1) // Only 1 concurrent launch allowed
+
+	bk := &mockBuildkite{
+		metrics: &buildkite.AgentMetrics{
+			ScheduledJobs: 3,
+			RunningJobs:   0,
+		},
+	}
+	gce := &mockGCE{
+		liveCount: 0,
+	}
+	stats := &mockStatsd{}
+	logger := hclog.NewNullLogger()
+
+	scaler := &Scaler{
+		cfg: &Config{
+			GCPProject:            "proj",
+			GCPZone:               "zone",
+			InstanceGroupName:     "group",
+			InstanceGroupTemplate: "tmpl",
+			MaxRunDuration:        60,
+		},
+		buildkite: bk,
+		gce:       gce,
+		logger:    logger,
+		Statsd:    stats,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = scaler.run(ctx, &sem)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// test finished
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not finish in time")
+	}
+	assert.Equal(t, 3, gce.launches)
+}


### PR DESCRIPTION
Add tests (thank you copilot) 
ensure tests pass
Scaler should always have one instance available to help be ready for new builds. 
Bump go to 1.22 